### PR TITLE
add footnote explaining billionth vs. trillionth

### DIFF
--- a/2.html
+++ b/2.html
@@ -86,9 +86,10 @@ half a minute in a year, it must keep time with an
 accuracy of $1$ part in $1,051,200$. Now if, for such a
 purpose, we regard $\frac{1}{1,000,000}$ (or one millionth) as a
 small quantity, then $\frac{1}{1,000,000}$ of $\frac{1}{1,000,000}$, that is
-$\frac{1}{1,000,000,000,000}$ (or one trillionth) will be a small
+$\frac{1}{1,000,000,000,000}$ (or one billionth<sup>†</sup>) will be a small
 quantity of the second order of smallness, and may
 be utterly disregarded, by comparison.
+
 
 <p>Then we see that the smaller a small quantity itself
 is, the more negligible does the corresponding small
@@ -197,6 +198,9 @@ would not be of much account to the ox.
 <hr>
 <a href="3.html">Next &rarr;</a><br>
 <a href="/">Main Page &uarr;</a><br>
+
+<p><note><sup>†</sup>The term <em>billion</em> often means 10<sup>12</sup> in British
+English.</note>
 
 <script src="j/jquery.js"></script>
 <script src="j/modernizr.js"></script>

--- a/2.html
+++ b/2.html
@@ -86,7 +86,7 @@ half a minute in a year, it must keep time with an
 accuracy of $1$ part in $1,051,200$. Now if, for such a
 purpose, we regard $\frac{1}{1,000,000}$ (or one millionth) as a
 small quantity, then $\frac{1}{1,000,000}$ of $\frac{1}{1,000,000}$, that is
-$\frac{1}{1,000,000,000,000}$ (or one billionth) will be a small
+$\frac{1}{1,000,000,000,000}$ (or one trillionth) will be a small
 quantity of the second order of smallness, and may
 be utterly disregarded, by comparison.
 


### PR DESCRIPTION
The text correctly uses 1,000,000 x 1,000,000 = 1,000,000,000,000 but incorrectly calls 1/this to be a billionth (1/1,000,000,000) rather than a trillionth.